### PR TITLE
Update docs to reflect new output format

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ version: 2
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
 
 # Python Version and requirements required to build docs
 python:

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -1,8 +1,8 @@
 Quickstart - Scancode Plugin
 ----------------------------
 
-``scancode-results-analyzer`` can be installed as a scancode post-scan plugin, using ``pip``.
-This is currently work-in-progress.
+``scancode-results-analyzer`` can be installed as a scancode post-scan plugin,
+using ``pip``.
 
 1. Ensure you have Virtualenv installed.
 
@@ -24,20 +24,28 @@ This is currently work-in-progress.
 
     scancode -h
 
-7. Run a scan using the ``--analyze-results`` command line options::
+7. Run a scan using the ``--analyze-license-results`` command line options::
 
-    scancode -l --json-pp output.json /path/to/scan_files/ --license-text --analyze-results
+    scancode -l --json-pp output.json /path/to/scan_files/ --license-text --is-license-text --classify --analyze-license-results
 
 8. OR, import a JSON scan result and run the plugin on that scan::
 
-    scancode --json-pp results.json --from-json tests/data/results-test/selective-before-rules-added/only_errors.json --analyze-results
+    scancode --json-pp results.json --from-json tests/data/results-test/selective-before-rules-added/only_errors.json --analyze-license-results
 
+.. note::
+
+    `scancode-results-analyzer` has required CLI options, as these produce attributes
+    essential to the analysis process. These are:
+    `--license --info --license-text --is-license-text --classify`
+    Even when loading from json, the scan generating these json files should have
+    been run with this options for the analysis plugin to work.
 
 Quickstart - Conda
 ------------------
 
-Different modules of ``scancode-results-analyzer`` can be imported as python modules, to test their functionality
-on scancode JSON scans. They need to be imported by using jupyter-notebooks in a ``conda`` environment.
+Different modules of ``scancode-results-analyzer`` can be imported as python modules,
+to test their functionality on scancode JSON scans. They need to be imported by using
+jupyter-notebooks in a ``conda`` environment.
 
 1. Download and Get Anaconda Installed.
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ Babel==2.8.0
 doc8==0.8.1
 docutils==0.16
 restructuredtext-lint==1.3.1
-nbsphinx=0.8.0
+nbsphinx==0.8.0
 Sphinx==3.2.1
 sphinx-autobuild==2020.9.1
 sphinx-rtd-theme==0.5.0

--- a/docs/source/analysis-use-case/index.rst
+++ b/docs/source/analysis-use-case/index.rst
@@ -2,4 +2,4 @@
 .. toctree::
    :maxdepth: 2
 
-   crafting-rules
+   suggesting-licenses

--- a/docs/source/analysis-use-case/suggesting-licenses.rst
+++ b/docs/source/analysis-use-case/suggesting-licenses.rst
@@ -1,17 +1,20 @@
 .. _resolving_issues:
 
-Crafting Rules From Fragments of Matched Text
-=============================================
+Suggesting New License Detection
+================================
+
+Firstly this analysis is then used to suggest new license matches in place of the matches with
+different license detection issues, to rectify those issues and provide a better license
+detection. This helps in quickly identifying issues when looking at a scan result or in
+larger use cases/audits.
+
+This can also help in sub-sequent rule addition in the scancode rules, to enhance the scancode
+data.
 
 .. note::
 
     The rule/.yml file generation/other actions is Work In Progress.
     Only reports with suggested rules with the rule text, license key, rule type is generated.
-
-The functions from stitching are implemented using the same algorithm mentioned above in Deleting
-Correct scans Location wise in File, because this is also done location wise, and wrt start and
-end line numbers. But the other rule/.yml generation is remaining according to different treatments
-for different classes of errors.
 
 .. _crafting_rule_text:
 
@@ -41,6 +44,26 @@ Now if they do not have a common boundary,
 
 - Less than or equal to 4 lines gap: They are joined as one Rule
 - More than 4 lines gap: They are made two separate rules
+
+
+.. _predict_license_expression:
+
+Predict License Expression
+--------------------------
+
+The steps are as follows:
+
+1. First from the list of `license expressions`, all the `license expressions` are sorted according
+   to their occurrences.
+
+2. Generic `license_expressions` like `unknown`, `warranty-disclaimer` are removed fro, this sorted
+   list.
+
+3. If there's only one `license_expression` with the most number of occurrences, then that is the
+   predicted `license_expression`.
+
+4. In case of same number of `license_expressions` for multiple matches, the `license_expression` of
+   the license match with the highest `matched_length` given as the prediction.
 
 .. _crafting_rule_yml:
 

--- a/docs/source/api-and-outputs/json-output.rst
+++ b/docs/source/api-and-outputs/json-output.rst
@@ -7,7 +7,7 @@ added to the scancode JSON results.
 
 Command Line Argument to use ``scancode-results-analyzer``: ``--analyze-results``
 
-Here's how example result-JSONs from `scancode-results-analyzer` could look like.
+Here's how example result-JSONs from `scancode-results-analyzer` could look like, post-analysis.
 
 .. _license_detection_issues_result_json:
 
@@ -20,15 +20,15 @@ dictionary, with relevant attributes and corresponding values.
 
 Now similarly the license detection analysis results will also be a resource-level list,
 for each resource in the codebase this list of dictionary will be added, where each dictionary
-is for each corresponding license match, having the results of the analysis for that match.
+is for each corresponding file-region :ref:`file_region`, having the results of the analysis for all
+the match(es) in that file-region.
 
 .. note::
 
-    [WIP] Optionally,
-    1. There would also be a codebase-level dictionary added, optionally, with statistics on the
+    [WIP]
+    1. Optionally, There would also be a codebase-level dictionary added, optionally, with statistics on the
     resource level information added, and some header information.
-    2. Another list of dictionary will be added per-resource, with created rules for each
-    file-region.
+    2. More Sub-cases of errors are being added.
 
 .. code-block:: json
 
@@ -52,7 +52,7 @@ is for each corresponding license match, having the results of the analysis for 
                         "path": "file1.cpp",
                     },
                 ]
-                "license_detection_errors": [
+                "license_detection_analysis": [
                     {
                         ...
                     },
@@ -65,7 +65,7 @@ is for each corresponding license match, having the results of the analysis for 
                         "path": "file2.cpp",
                     },
                 ]
-                "license_detection_errors": [
+                "license_detection_analysis": [
                     {
                         ...
                     },
@@ -79,8 +79,8 @@ is for each corresponding license match, having the results of the analysis for 
 Scan errors
 -----------
 
-The attribute ``license_detection_errors`` is a list of dictionaries, each dictionary representing a
-license match, in that file.
+The attribute ``license_detection_analysis`` is a list of dictionaries, each dictionary representing a
+file-region, and containing analysis results for all the license matches in a file-region.
 
 .. code-block:: json
 
@@ -91,20 +91,30 @@ license match, in that file.
                 "path": "file1.cpp",
             },
         ]
-        "license_detection_errors": [
-            {
-                "location_region_number": 1,
-                "license_scan_analysis_result": "imperfect_match_coverage",
-                "region_license_error_case": "tag",
-                "region_license_error_sub_case": "false-positive",
-            }
-        ]
+        "license_detection_analysis": [
+        {
+          "start_line_region": 3,
+          "end_line_region": 3,
+          "license_matches": [
+            ...
+          ],
+          "license_match_post_analysis": {
+            "key": "gpl-2.0",
+            "matched_text": "/* Published under the GNU General Public License V.2, see file COPYING */"
+          },
+          "license_scan_analysis_result": "imperfect-match-coverage",
+          "license_scan_analysis_result_description": "The license detection is incorrect, a large variation is present from the matched rule(s) and is matched to only one part of the whole text",
+          "region_license_error_case": "notice",
+          "region_license_error_case_description": "A notice referencing the license name and some terms/implications are present in the matched text",
+          "region_license_error_sub_case": "notice-single-key-notice",
+          "region_license_error_sub_case_description":  "a notice that notifies a single license",
+        }
     }
 
 The attributes containing the analysis results are:
 
-1. ``location_region_number``
-   :ref:`location_region_number`
+1.  `start_line_region`, `end_line_region` and `license_matches`
+   :ref:`location_regions_division`
 2. ``license_scan_analysis_result``
    :ref:`license_scan_analysis_result`
 3. ``region_license_error_case``
@@ -114,60 +124,59 @@ The attributes containing the analysis results are:
 
 .. _license_scan_issue_example:
 
-Scan Errors per File
---------------------
+Scan Errors per File-Region
+---------------------------
 
-This is a dict for every file, which has one or more matches in each file, which would be
-grouped together by location.
-
-Here only the matches with errors will be shown, by match, in lists.
+This is a dict for every file-region, which has one or more matches in them, grouped together by location.
 
 .. code-block:: json
 
      {
         "files": [
-        {
-            "path": 'path/to/1914-gpiolib.c',
-            "licenses": [],
-            "licence_detection_errors": [
-                {
-                    "location_region_number": 1,
-                    "license_scan_analysis_result": "false-positive",
-                    "region_license_error_case": "tag",
-                    "region_license_error_sub_case": "false-positive",
-                }
-            ]
-        },
-        {
-            "path": 'path/to/Issues/1912-libtool-2.2.10-argz.c',
-            "licenses": [],
-            "lic-detection-errors": [
-                {
-                    "location_region_number": 1,
-                    "license_scan_analysis_result": "imperfect_match_coverage",
-                    "region_license_error_case": "notice",
-                    "region_license_error_sub_case": "single-key-notice",
-                },
-                {
-                    "location_region_number": 1,
-                    "license_scan_analysis_result": "imperfect_match_coverage",
-                    "region_license_error_case": "notice",
-                    "region_license_error_sub_case": "single-key-notice",
-                },
-                {
-                    "location_region_number": 2,
-                    "license_scan_analysis_result": "imperfect_match_coverage"
-                    "region_license_error_case": "reference",
-                    "region_license_error_sub_case": "reference-low-score",
-                },
-                {
-                    "location_region_number": 2,
-                    "license_scan_analysis_result": "imperfect_match_coverage"
-                    "region_license_error_case": "reference",
-                    "region_license_error_sub_case": "reference-low-score",
-                },
-            ]
-        }
+            {
+                "scan-files/genshell.c",
+                "licenses": [
+                    ...
+                ],
+                "licence_detection_analysis": [
+                    {
+                        "start_line_region": 14,
+                        "end_line_region": 34,
+                        "license_matches": [
+                            ...
+                        ],
+                        "license_match_post_analysis": {
+                            "key": "agpl-3.0-plus",
+                            "rule_text": " *  licensed under the terms of the LGPL.  The redistributable library\n *  (``libopts'') is licensed under the terms of either the LGPL or, at the\n *  users discretion, the BSD license.
+                        },
+                        "license_scan_analysis_result": "imperfect-match-coverage",
+                        "license_scan_analysis_result_description": "The license detection is incorrect, a large variation is present from the matched rule(s) and is matched to only one part of the whole text",
+                        "region_license_error_case": "notice",
+                        "region_license_error_case_description": "A notice referencing the license name and some terms/implications are present in the matched text",
+                        "region_license_error_sub_case": null,
+                        "region_license_error_sub_case_description": null
+                    },
+                    {
+                        "start_line_region": 54,
+                        "end_line_region": 62,
+                        "license_matches": [
+                            ...
+                        ],
+                        "license_match_post_analysis": {
+                            "key": "gpl-3.0-plus",
+                            "matched_text": "\"genshellopt is free software: you can redistribute it and/or modify it under \\\nthe terms of the GNU General Public License as published by the Free Software \\\nFoundation, either version 3 of the License, or (at your option) any later \\\nversion."
+                        },
+                        "license_scan_analysis_result": "extra-words",
+                        "license_scan_analysis_result_description": "A license rule from the scancode rules matches completely with a part of the text, but there's some extra words which aren't there in the rule",
+                        "region_license_error_case": "notice",
+                        "region_license_error_case_description": "A notice referencing the license name and some terms/implications are present in the matched text",
+                        "region_license_error_sub_case": null,
+                        "region_license_error_sub_case_description": null
+                        }
+                    }
+                ]
+            }
+        ]
     }
 
 .. _generated_rules_json_format:
@@ -175,51 +184,99 @@ Here only the matches with errors will be shown, by match, in lists.
 Generated Rules
 ---------------
 
-This is a list of files, as there could be more than one generated rule per file, as there might
-be multiple areas of interest, grouped by location, and one generated rule per area.
+There are 3 cases of file-regions and corresponding different outputs for each:
 
-Contains rule text, as well as rule attributes, along with identifiers to link with scan results.
+    1. Correct Detection. :ref:`correct-detection-json-output`
+    2. Incorrect Detection but only one match in a file-region. (or multiple joined by AND/OR/EXCEPT) :ref:`incorrect-detection-one-match`
+    3. Incorrect Detection but multiple (often fragments) matches in a file-region. :ref:`incorrect-detection-multiple-match-fragments`
 
-This would be a separate plugin: ``--generate-rules``, and would have ``--analyze-results`` as a
-pre-requisite.
+.. _correct-detection-json-output:
+
+1. Correct Detection
+^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: json
 
-     {
-        "files": [
+    {
+        "license_detection_analysis": [
         {
-            "path": Issues/1918-ntp-4.2.6/genshell.c,
-            "has_license_detection_errors": True,
-            "license_detection_errors": [
-                    {
-                        ...
-                    },
+            "start_line_region": 9,
+            "end_line_region": 22,
+            "license_matches": [
+                ...                 # The correctly detected license match would be here
             ],
-            "generated_rules": [
-                {
-                    "rule-text": "* licensed under the terms of the LGPL. The redistributable library\n * (``libopts'') is licensed under the terms of either the LGPL or, at the\n * users discretion, the BSD license. See the AutoOpts and/or libopts sources\n * for details.\n *\n * This source file is copyrighted and licensed under the following terms:\n *\n * genshellopt copyright (c) 1999-2009 Bruce Korb - all rights reserved\n *\n * genshellopt is free software: you can redistribute it and/or modify it\n * under the terms of the GNU General Public License as published by the\n * Free Software Foundation, either version 3 of the License, or\n * (at your option) any later version.\n * \n * genshellopt is distributed in the hope that it will be useful, but\n * WITHOUT ANY WARRANTY; without even the implied warranty of\n * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n * See the GNU General Public License for more details.\n * \n * You should have received a copy of the GNU General Public License along\n * with this program. If not, see <http://www.gnu.org/licenses/>.",
-                    "is-negative": false,
-                    "key-id": 52,
-                    "key": lgpl,
-                    "rule_class": notice,
-                    "start_line": 14,
-                    "end_line": 34,
-                    "rule-confidence": high,
+            "license_match_post_analysis": null
+            "license_scan_analysis_result": "correct-license-detection",
+            "license_scan_analysis_result_description": "The license detection is correct",
+            "region_license_error_case": null,
+            "region_license_error_case_description": null,
+            "region_license_error_sub_case": null,
+            "region_license_error_sub_case_description": null
+        ]
+    }
+
+.. _incorrect-detection-one-match:
+
+2. Incorrect Detection (one match)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: json
+
+    {
+        "license_detection_analysis": [
+            {
+                "start_line_region": 3,
+                "end_line_region": 3,
+                "license_matches": [
+                ...                     # The wrongly detected license match would be here
+                ],
+                "license_match_post_analysis": {
+                    "key": "gpl-2.0",
+                    "matched_text": "/* Published under the GNU General Public License V.2, see file COPYING */"
                 },
-                {
-                    "rule-text": "\t\t\t.base\t= S5PC100_GPL1(0)",
-                    "is-negative": true,
-                    "rule-confidence": high,
+                "license_scan_analysis_result": "imperfect-match-coverage",
+                "license_scan_analysis_result_description": "The license detection is incorrect, a large variation is present from the matched rule(s) and is matched to only one part of the whole text",
+                "region_license_error_case": "notice",
+                "region_license_error_case_description": "A notice referencing the license name and some terms/implications are present in the matched text",
+                "region_license_error_sub_case": "notice-single-key-notice",
+                "region_license_error_sub_case_description": "a notice that notifies a single license",
+            }
+        ]
+    }
+
+.. _incorrect-detection-multiple-match-fragments:
+
+3. Incorrect Detection (multiple matches)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: json
+
+    {
+        "license_detection_analysis": [
+            {
+                "start_line_region": 14,
+                "end_line_region": 34,
+                "license_matches": [
+                    ...                       # The wrongly detected license matches would be here
+                ],
+                "license_match_post_analysis": {
+                    "key": "agpl-3.0-plus",
+                    "rule_text": " *  licensed under the terms of the LGPL.  The redistributable library\n *  (``libopts'') is licensed under the terms of either the LGPL or, at the\n *  users discretion, the BSD license.
                 },
-            ],
-        },
-        ],
+                "license_scan_analysis_result": "imperfect-match-coverage",
+                "license_scan_analysis_result_description": "The license detection is incorrect, a large variation is present from the matched rule(s) and is matched to only one part of the whole text",
+                "region_license_error_case": "notice",
+                "region_license_error_case_description": "A notice referencing the license name and some terms/implications are present in the matched text",
+                "region_license_error_sub_case": "notice-single-key-notice",
+                "region_license_error_sub_case_description": "a notice that notifies a single license",
+            }
+        ]
     }
 
 .. _json_package_level_stats:
 
-Basic Statistics
-----------------
+Basic Statistics [WIP]
+----------------------
 
 These are some basic statistics on the scan license info in files, and their errors detected for
 quick glances into as a summary. This is also a codebase-level optional dict, that could be added.
@@ -232,22 +289,42 @@ This would be a separate ``summary`` plugin: ``--results-analyzer-summary``.
         "basic_stats": {
             "total-files-scanned": 9795,
             "total-scan-errors": 7048,
-            "total-scan-errors-unique": 1067,
-            "total-scan-errors-unique-by-location": 345,
-            "errors-by-license-classes": {
-                "license-text": 3,
-                "license-notice": 45,
-                "license-tag": 6,
-                "license-reference": 37,
-                "tag-false-positives": 8,
+            "total-scan-errors-unique": {
+                "file-regions": 345,
+                "total-matches": 1067,
             },
-            "scan-errors-by-score-classes": {
+            "scan-errors-by-main-score-classes": {
+                "correct-detection": 289,
                 "extra-words": 4,
                 "low-score": 34,
-                "high-but-imperfect-score": ,
+                "high-but-imperfect-score": 0,
                 "false-pos-perfect-score": 8,
             },
-            "rules-generated": 34,
+            "errors-by-license-classes": {
+                "license-text": {
+                    "total": 3,
+                    "text-legal-lic-files": 0,
+                    "text-non-legal-lic-files": 0,
+                    "text-lic-text-fragments": 3,
+                },
+                "license-notice": {
+                    "total": 45,
+                    "notice-and-or-except-notice": ,
+                    "notice-single-key-notice": "a notice that notifies a single license",
+                },
+                "license-tag": {
+                    "total": 14,
+                    "tag-tag-coverage": 6,
+                    "tag-other-tag-structures": 0,
+                    "tag-false-positives": 8,
+                },
+                "license-reference": {
+                    "total": 37,
+                    "reference-lead-in-refs": 7,
+                    "reference-low-coverage-refs": 21,
+                    "reference-unknown-refs": 9,
+                }
+            },
             "rules-by-confidence": {
                 "high-confidence": 18,
                 "review-needed": 12,
@@ -270,6 +347,7 @@ BERT model versions used.
         "header": {
             "tool_name": scancode-results-analyzer,
             "version": 0.1,
+            "cases_version": 0.1,
             "ml_models": [
                 {
                     "name": lic-class-scancode-bert-base-cased-L32-1,
@@ -282,14 +360,14 @@ BERT model versions used.
                         "License Text": 1,
                         "License Notice": 2,
                         "License Tag": 3,
-                        "License Referance": 4
+                        "License Reference": 4
                     ],
                 },
                 {
                     "name": false-positives-scancode-bert-base-uncased-L8-1,
                     "type": sentence-classifier-bert,
                     "link": https://huggingface.co/ayansinha/false-positives-scancode-bert-base-uncased-L8-1,
-                    "model": BertBaseUnased,
+                    "model": BertBaseUncased,
                     "Sentence Length": 8,
                     "Labels": 2,
                     "Label_Names": [

--- a/docs/source/api-and-outputs/json-output.rst
+++ b/docs/source/api-and-outputs/json-output.rst
@@ -26,52 +26,54 @@ the match(es) in that file-region.
 .. note::
 
     [WIP]
-    1. Optionally, There would also be a codebase-level dictionary added, optionally, with statistics on the
-    resource level information added, and some header information.
-    2. More Sub-cases of errors are being added.
+    There would also be a codebase-level dictionary added,
+    1. With statistics on the license_detection issues.
+    2. All the unique license detection issues and their occurrences.
+    3. Header information.
 
 .. code-block:: json
 
     {
-        "headers": [
-            {
-            "tool_name": "scancode-toolkit",
-            "tool_version": "3.1.1.post351.850399bc3",
-            "options": {
-                "input": [
-                "/path_to/downloaded_licenses/"
-                ],
-                "--analyze-license-results": true,
-            }
-        ],
-        "files": [
-            {
-                "path": 'path/to/file',
-                "licenses": [
-                    {
-                        "path": "file1.cpp",
-                    },
-                ]
-                "license_detection_analysis": [
-                    {
-                        ...
-                    },
-                ]
-            }
-            {
-                "path": 'path/to/file2',
-                "licenses": [
-                    {
-                        "path": "file2.cpp",
-                    },
-                ]
-                "license_detection_analysis": [
-                    {
-                        ...
-                    },
-                ]
-            },
-        ]
+      "headers": [
+        {
+          "tool_name": "scancode-toolkit",
+          "tool_version": "3.1.1.post351.850399bc3",
+          "options": {
+            "input": [
+              "/path_to/downloaded_licenses/"
+            ],
+            "--analyze-license-results": true
+          }
+        }
+      ],
+      "files": [
+          {
+              "path": "path/to/file",
+              "licenses": [
+                  {
+                      "path": "file1.cpp"
+                  }
+              ],
+              "license_detection_issues": [
+                  {
+                    "issue_id": "correct-detection"
+                  }
+              ]
+          },
+          {
+              "path": "path/to/file2",
+              "licenses": [
+                  {
+                      "path": "file2.cpp"
+                  }
+              ],
+              "license_detection_issues": [
+                  {
+                      "issue_id": "false-positive"
+                  }
+              ]
+          }
+      ]
     }
 
 .. _license_scan_issues:
@@ -79,100 +81,123 @@ the match(es) in that file-region.
 Scan errors
 -----------
 
-The attribute ``license_detection_analysis`` is a list of dictionaries, each dictionary representing a
-file-region, and containing analysis results for all the license matches in a file-region.
+The attribute ``license_detection_issues`` is a list of dictionaries, each dictionary representing
+a file-region, and containing analysis results for all the license matches in a file-region.
 
 .. code-block:: json
 
     {
-        "path": 'path/to/file',
+        "path": "path/to/file",
         "licenses": [
             {
-                "path": "file1.cpp",
-            },
+                "path": "file1.cpp"
+            }
+        ],
+        "license_detection_issues": [
+            {
+                "start_line": 3,
+                "end_line": 3,
+                "issue_id": "imperfect-match-coverage",
+                "issue_description": "The license detection is incorrect, a large variation is present from the matched rule(s) and is matched to only one part of the whole text",
+                "issue_type": {
+                    "classification_id": "notice-single-key-notice",
+                    "classification_description":  "a notice that notifies a single license",
+                    "is_license_text": false,
+                    "is_license_notice": true,
+                    "is_license_tag": false,
+                    "is_license_reference": false,
+                    "analysis_confidence": "high",
+                    "is_suggested_matched_text_complete": true
+                },
+                "suggested_license": {
+                    "license_expression": "gpl-2.0",
+                    "matched_text": "/* Published under the GNU General Public License V.2, see file COPYING */"
+                },
+                "original_licenses": [
+                    {
+                        "key": "mit"
+                    }
+                ]
+            }
         ]
-        "license_detection_analysis": [
-        {
-          "start_line_region": 3,
-          "end_line_region": 3,
-          "license_matches": [
-            ...
-          ],
-          "license_match_post_analysis": {
-            "key": "gpl-2.0",
-            "matched_text": "/* Published under the GNU General Public License V.2, see file COPYING */"
-          },
-          "license_scan_analysis_result": "imperfect-match-coverage",
-          "license_scan_analysis_result_description": "The license detection is incorrect, a large variation is present from the matched rule(s) and is matched to only one part of the whole text",
-          "region_license_error_case": "notice",
-          "region_license_error_case_description": "A notice referencing the license name and some terms/implications are present in the matched text",
-          "region_license_error_sub_case": "notice-single-key-notice",
-          "region_license_error_sub_case_description":  "a notice that notifies a single license",
-        }
     }
 
 The attributes containing the analysis results are:
 
-1.  `start_line_region`, `end_line_region` and `license_matches`
-   :ref:`location_regions_division`
-2. ``license_scan_analysis_result``
-   :ref:`license_scan_analysis_result`
-3. ``region_license_error_case``
-   :ref:`dividing_into_more_cases`
-4. ``region_license_error_sub_case``
-   :ref:`cases_sub_cases_table`
+These 3 attributes in the analysis results has information on which file-region the matches are in.
+
+    1. ``start_line`` and ``end_line`` marking the issue location in file
+    2. ``issue_id`` and ``issue_description`` is what kind of issue it is and it's description.
+    3. ``issue_type`` has further types of issues and their related attributes, listed below.
+    4. ``original_license`` having the license matches with issues.
+
+The issue type has these attributes:
+
+    1. ``classification_id`` and ``classification_description``
+    2. 4 boolean fields ``is_license_text``, ``is_license_notice``, ``is_license_tag``, and
+       ``is_license_reference``.
+    3. ``is_suggested_matched_text_complete`` and ``analysis_confidence``
 
 .. _license_scan_issue_example:
 
 Scan Errors per File-Region
 ---------------------------
 
-This is a dict for every file-region, which has one or more matches in them, grouped together by location.
+This is a dict for every file-region, which has one or more matches in them, grouped together by
+location.
 
 .. code-block:: json
 
      {
         "files": [
             {
-                "scan-files/genshell.c",
+                "path": "scan-files/genshell.c",
                 "licenses": [
-                    ...
+                  {
+                    "key": "lgpl-2.0"
+                  }
                 ],
                 "licence_detection_analysis": [
                     {
-                        "start_line_region": 14,
-                        "end_line_region": 34,
-                        "license_matches": [
-                            ...
-                        ],
-                        "license_match_post_analysis": {
-                            "key": "agpl-3.0-plus",
-                            "rule_text": " *  licensed under the terms of the LGPL.  The redistributable library\n *  (``libopts'') is licensed under the terms of either the LGPL or, at the\n *  users discretion, the BSD license.
+                        "start_line": 14,
+                        "end_line": 34,
+                        "issue_id": "imperfect-match-coverage",
+                        "issue_description": "The license detection is inconclusive with high confidence, because only a small part of the rule text is matched.",
+                        "issue_type": {
+                            "classification_id": "notice-has-unknown-match",
+                            "classification_description": "License notices with unknown licenses detected.",
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_tag": false,
+                            "is_license_reference": false,
+                            "analysis_confidence": "medium",
+                            "is_suggested_matched_text_complete": true
                         },
-                        "license_scan_analysis_result": "imperfect-match-coverage",
-                        "license_scan_analysis_result_description": "The license detection is incorrect, a large variation is present from the matched rule(s) and is matched to only one part of the whole text",
-                        "region_license_error_case": "notice",
-                        "region_license_error_case_description": "A notice referencing the license name and some terms/implications are present in the matched text",
-                        "region_license_error_sub_case": null,
-                        "region_license_error_sub_case_description": null
+                        "suggested_license": {
+                            "license_expression": "lgpl-2.0-plus",
+                            "matched_text": " *  licensed under the terms of the LGPL.... "
+                        }
                     },
                     {
-                        "start_line_region": 54,
-                        "end_line_region": 62,
-                        "license_matches": [
-                            ...
-                        ],
-                        "license_match_post_analysis": {
-                            "key": "gpl-3.0-plus",
+                        "start_line": 54,
+                        "end_line": 62,
+                        "issue_id": "extra-words",
+                        "issue_description": "The license detection is conclusive with high confidence because all the rule text is matched, but some unknown extra words have been inserted in the text.",
+                        "issue_type": {
+                            "classification_id": "notice-single-key-notice",
+                            "classification_description":  "A notice with a single license.",
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_tag": false,
+                            "is_license_reference": false,
+                            "analysis_confidence": "high",
+                            "is_suggested_matched_text_complete": true
+                        },
+                        "suggested_license": {
+                            "license_expression": "gpl-3.0-plus",
                             "matched_text": "\"genshellopt is free software: you can redistribute it and/or modify it under \\\nthe terms of the GNU General Public License as published by the Free Software \\\nFoundation, either version 3 of the License, or (at your option) any later \\\nversion."
                         },
-                        "license_scan_analysis_result": "extra-words",
-                        "license_scan_analysis_result_description": "A license rule from the scancode rules matches completely with a part of the text, but there's some extra words which aren't there in the rule",
-                        "region_license_error_case": "notice",
-                        "region_license_error_case_description": "A notice referencing the license name and some terms/implications are present in the matched text",
-                        "region_license_error_sub_case": null,
-                        "region_license_error_sub_case_description": null
-                        }
+                        "original_licenses": []
                     }
                 ]
             }
@@ -187,32 +212,23 @@ Generated Rules
 There are 3 cases of file-regions and corresponding different outputs for each:
 
     1. Correct Detection. :ref:`correct-detection-json-output`
-    2. Incorrect Detection but only one match in a file-region. (or multiple joined by AND/OR/EXCEPT) :ref:`incorrect-detection-one-match`
-    3. Incorrect Detection but multiple (often fragments) matches in a file-region. :ref:`incorrect-detection-multiple-match-fragments`
+    2. Incorrect Detection but only one match in a file-region. :ref:`incorrect-detection-one-match`
+    3. Incorrect Detection but multiple matches in a file-region.
+       :ref:`incorrect-detection-multiple-match-fragments`
 
 .. _correct-detection-json-output:
 
 1. Correct Detection
 ^^^^^^^^^^^^^^^^^^^^
 
+In case of a correct license detection the issue has no corresponding dictionary
+in `license_detection_issues`, and if all the licenses in a resource are correctly detected,
+it is an empty list.
+
 .. code-block:: json
 
     {
-        "license_detection_analysis": [
-        {
-            "start_line_region": 9,
-            "end_line_region": 22,
-            "license_matches": [
-                ...                 # The correctly detected license match would be here
-            ],
-            "license_match_post_analysis": null
-            "license_scan_analysis_result": "correct-license-detection",
-            "license_scan_analysis_result_description": "The license detection is correct",
-            "region_license_error_case": null,
-            "region_license_error_case_description": null,
-            "region_license_error_sub_case": null,
-            "region_license_error_sub_case_description": null
-        ]
+        "license_detection_issues": []
     }
 
 .. _incorrect-detection-one-match:
@@ -225,21 +241,32 @@ There are 3 cases of file-regions and corresponding different outputs for each:
     {
         "license_detection_analysis": [
             {
-                "start_line_region": 3,
-                "end_line_region": 3,
-                "license_matches": [
-                ...                     # The wrongly detected license match would be here
-                ],
-                "license_match_post_analysis": {
-                    "key": "gpl-2.0",
-                    "matched_text": "/* Published under the GNU General Public License V.2, see file COPYING */"
+                "start_line": 14,
+                "end_line": 34,
+                "issue_id": "imperfect-match-coverage",
+                "issue_description": "The license detection is inconclusive with high confidence, because only a small part of the rule text is matched.",
+                "issue_type": {
+                    "classification_id": "notice-has-unknown-match",
+                    "classification_description": "License notices with unknown licenses detected.",
+                    "is_license_text": false,
+                    "is_license_notice": true,
+                    "is_license_tag": false,
+                    "is_license_reference": false,
+                    "analysis_confidence": "medium",
+                    "is_suggested_matched_text_complete": true
                 },
-                "license_scan_analysis_result": "imperfect-match-coverage",
-                "license_scan_analysis_result_description": "The license detection is incorrect, a large variation is present from the matched rule(s) and is matched to only one part of the whole text",
-                "region_license_error_case": "notice",
-                "region_license_error_case_description": "A notice referencing the license name and some terms/implications are present in the matched text",
-                "region_license_error_sub_case": "notice-single-key-notice",
-                "region_license_error_sub_case_description": "a notice that notifies a single license",
+                "suggested_license": {
+                    "license_expression": "lgpl-2.0-plus",
+                    "matched_text": " *  licensed under the terms of the LGPL...."
+                },
+                "original_licenses": [
+                    {
+                        "key": "unknown"
+                    },
+                    {
+                        "key": "lgpl-2.0-plus"
+                    }
+                ]
             }
         ]
     }
@@ -254,29 +281,36 @@ There are 3 cases of file-regions and corresponding different outputs for each:
     {
         "license_detection_analysis": [
             {
-                "start_line_region": 14,
-                "end_line_region": 34,
-                "license_matches": [
-                    ...                       # The wrongly detected license matches would be here
-                ],
-                "license_match_post_analysis": {
-                    "key": "agpl-3.0-plus",
-                    "rule_text": " *  licensed under the terms of the LGPL.  The redistributable library\n *  (``libopts'') is licensed under the terms of either the LGPL or, at the\n *  users discretion, the BSD license.
+                "start_line": 14,
+                "end_line": 34,
+                "issue_id": "imperfect-match-coverage",
+                "issue_description": "The license detection is inconclusive with high confidence, because only a small part of the rule text is matched.",
+                "issue_type": {
+                    "classification_id": "notice-has-unknown-match",
+                    "classification_description": "License notices with unknown licenses detected.",
+                    "is_license_text": false,
+                    "is_license_notice": true,
+                    "is_license_tag": false,
+                    "is_license_reference": false,
+                    "analysis_confidence": "medium",
+                    "is_suggested_matched_text_complete": true
                 },
-                "license_scan_analysis_result": "imperfect-match-coverage",
-                "license_scan_analysis_result_description": "The license detection is incorrect, a large variation is present from the matched rule(s) and is matched to only one part of the whole text",
-                "region_license_error_case": "notice",
-                "region_license_error_case_description": "A notice referencing the license name and some terms/implications are present in the matched text",
-                "region_license_error_sub_case": "notice-single-key-notice",
-                "region_license_error_sub_case_description": "a notice that notifies a single license",
+                "suggested_license": {
+                    "license_expression": "lgpl-2.0-plus",
+                    "matched_text": " *  licensed under the terms of the LGPL. "
+                }
             }
         ]
     }
 
 .. _json_package_level_stats:
 
-Basic Statistics [WIP]
-----------------------
+Basic Statistics
+----------------
+
+.. note::
+
+    This is Work In Progress.
 
 These are some basic statistics on the scan license info in files, and their errors detected for
 quick glances into as a summary. This is also a codebase-level optional dict, that could be added.
@@ -287,50 +321,74 @@ This would be a separate ``summary`` plugin: ``--results-analyzer-summary``.
 
     {
         "basic_stats": {
-            "total-files-scanned": 9795,
-            "total-scan-errors": 7048,
-            "total-scan-errors-unique": {
+            "total_files_scanned": 9795,
+            "total-scan_issues": 7048,
+            "total_scan_issues_unique": {
                 "file-regions": 345,
-                "total-matches": 1067,
+                "total-matches": 1067
             },
-            "scan-errors-by-main-score-classes": {
-                "correct-detection": 289,
+            "license_issue_types": {
+                "correct-license-detection": 289,
                 "extra-words": 4,
-                "low-score": 34,
-                "high-but-imperfect-score": 0,
-                "false-pos-perfect-score": 8,
+                "imperfect-match-coverage": 34,
+                "near-perfect-match-coverage": 0,
+                "false-positive": 8,
+                "unknown-matched": 4
             },
-            "errors-by-license-classes": {
+            "unique_issues_by_license_classes": {
                 "license-text": {
                     "total": 3,
                     "text-legal-lic-files": 0,
                     "text-non-legal-lic-files": 0,
-                    "text-lic-text-fragments": 3,
+                    "text-lic-text-fragments": 3
                 },
                 "license-notice": {
                     "total": 45,
-                    "notice-and-or-except-notice": ,
-                    "notice-single-key-notice": "a notice that notifies a single license",
+                    "notice-and-or-except-notice": 6,
+                    "notice-single-key-notice": 11,
+                    "notice-has-unknown-match": 28,
+                    "notice-false-positive": 0
                 },
                 "license-tag": {
                     "total": 14,
                     "tag-tag-coverage": 6,
                     "tag-other-tag-structures": 0,
-                    "tag-false-positives": 8,
+                    "tag-false-positives": 8
                 },
                 "license-reference": {
                     "total": 37,
-                    "reference-lead-in-refs": 7,
-                    "reference-low-coverage-refs": 21,
-                    "reference-unknown-refs": 9,
+                    "reference-lead-in-or-unknown-refs": 7,
+                    "reference-to-local-file": 21,
+                    "reference-false-positive": 9
                 }
             },
-            "rules-by-confidence": {
-                "high-confidence": 18,
-                "review-needed": 12,
-                "review-needed-with-scanned-file": 4,
-            }
-        },
+            "analysis_confidence": {
+                "high": 18,
+                "medium": 12,
+                "low": 4
+            },
+            "is_suggested_matched_text_complete": {
+                "True": 24,
+                "False": 3
+            },
+            "all_unique_issues": [
+                {
+                    "suggested_licenses": {
+                        "license_expression": "apache-2.0",
+                        "matched_text": "This is licensed under the Apache 2.0 License."
+                    },
+                    "match_coverage_matched_rule": [23, "apache2_23.RULE"],
+                    "all_occurrences": [
+                        "path/to/analyzer.py",
+                        "path/to/analyzer_plugin.py"
+                    ],
+                    "original_licenses": {
+                        "score": 23,
+                        "matched_text": "This is licensed under the Apache 2.0 License."
+                    }
+                }
+            ]
+        }
     }
 
 .. _json_header_analyzer:
@@ -341,46 +399,49 @@ Header Text
 This could be an optional, codebase-level header dict, which has details on the analyzer and
 BERT model versions used.
 
+.. note::
+
+    This is Work In Progress.
+
 .. code-block:: json
 
     {
         "header": {
-            "tool_name": scancode-results-analyzer,
+            "tool_name": "scancode-results-analyzer",
             "version": 0.1,
             "cases_version": 0.1,
             "ml_models": [
                 {
-                    "name": lic-class-scancode-bert-base-cased-L32-1,
-                    "type": sentence-classifier-bert,
-                    "link": https://huggingface.co/ayansinha/lic-class-scancode-bert-base-cased-L32-1,
-                    "model": BertBaseCased,
+                    "name": "lic-class-scancode-bert-base-cased-L32-1",
+                    "type": "sentence-classifier-bert",
+                    "link": "https://huggingface.co/ayansinha/lic-class-scancode-bert-base-cased-L32-1",
+                    "model": "BertBaseCased",
                     "Sentence Length": 32,
                     "Labels": 4,
-                    "Label Names": [
-                        "License Text": 1,
-                        "License Notice": 2,
-                        "License Tag": 3,
-                        "License Reference": 4
-                    ],
+                    "Label Names": {
+                      "License Text": 1,
+                      "License Notice": 2,
+                      "License Tag": 3,
+                      "License Reference": 4
+                    }
                 },
                 {
-                    "name": false-positives-scancode-bert-base-uncased-L8-1,
-                    "type": sentence-classifier-bert,
-                    "link": https://huggingface.co/ayansinha/false-positives-scancode-bert-base-uncased-L8-1,
-                    "model": BertBaseUncased,
+                    "name": "false-positives-scancode-bert-base-uncased-L8-1",
+                    "type": "sentence-classifier-bert",
+                    "link": "https://huggingface.co/ayansinha/false-positives-scancode-bert-base-uncased-L8-1",
+                    "model": "BertBaseUncased",
                     "Sentence Length": 8,
                     "Labels": 2,
-                    "Label_Names": [
-                        "License Tag": 1,
-                        "False Positive": 2
-                    ],
-                },
+                    "Label_Names": {
+                      "License Tag": 1,
+                      "False Positive": 2
+                    }
+                }
             ],
             "low_score_threshold": 95,
-            "group_location_lines_threshold": 4,
-        },
+            "group_location_lines_threshold": 4
+        }
     }
-
 
 Related Issues
 --------------

--- a/docs/source/api-and-outputs/json-output.rst
+++ b/docs/source/api-and-outputs/json-output.rst
@@ -5,7 +5,7 @@ JSON Output Format
 running a scan, the scan results are then analyzed for scan errors, and that information is
 added to the scancode JSON results.
 
-Command Line Argument to use ``scancode-results-analyzer``: ``--analyze-results``
+Command Line Argument to use ``scancode-results-analyzer``: ``--analyze-license-results``
 
 Here's how example result-JSONs from `scancode-results-analyzer` could look like, post-analysis.
 
@@ -41,7 +41,7 @@ the match(es) in that file-region.
                 "input": [
                 "/path_to/downloaded_licenses/"
                 ],
-                "--analyze-results": true,
+                "--analyze-license-results": true,
             }
         ],
         "files": [

--- a/docs/source/how-analysis-is-performed/cases-incorrect-scans.rst
+++ b/docs/source/how-analysis-is-performed/cases-incorrect-scans.rst
@@ -26,81 +26,111 @@ NLP Sentence Classifiers (BERT), fine-tuned on the Scancode Rules.
 Result Attributes
 -----------------
 
-In the results of the analysis, two of the attributes has this information:
+In the results of the analysis, the attributes having this information is ``issue_type``.
 
-    1. ``region_license_error_case``
-    2. ``region_license_error_sub_case``
+This further has many attributes:
 
-Here, the ``region_license_error_case`` attribute represents the main issue types in terms of how
-clearly the license information is referred to. The 4 possible values of this are:
+    1. ``classification_id`` and ``classification_description``
+    2. 4 boolean fields ``is_license_text``, ``is_license_notice``, ``is_license_tag``, and
+       ``is_license_reference``.
+    3. ``is_suggested_matched_text_complete`` and ``analysis_confidence``
 
-- `text` - :ref:`case_lic_text`
-- `notice` - :ref:`case_lic_notice`
-- `tag` - :ref:`case_lic_tag`
-- `reference` - :ref:`case_lic_ref`
 
-The ``region_license_error_sub_case`` attribute represents further types of cases in these.
+Here, the ``classification_id`` attribute is a id which corresponds to a issue type from
+`all possible issue types <issue_types_table>`_, which the license detection issue is
+classified into. The ``classification_description`` describes the `issue_type` to provide
+more information and context about the analysis.
 
-.. _cases_sub_cases_table:
+There are 4 main types of issues in `issue_type` and these correspond to the 4 boolean flags in
+scancode rules:
 
-All Cases and their Sub-cases Table
------------------------------------
+- ``is_license_text`` - :ref:`case_lic_text`
+- ``is_license_notice`` - :ref:`case_lic_notice`
+- ``is_license_tag`` - :ref:`case_lic_tag`
+- ``is_license_reference`` - :ref:`case_lic_ref`
+
+Now the ``analysis_confidence`` is an approximate measure of how accurate the classification into
+these `issue_types` are (and not a measure of whether it is an issue or not). It has 3 values:
+
+    1. `high`, 2. `medium` and 3. `low`
+
+In many cases, and mostly in cases of a new license text, there are significant differences
+between already seen licenses and this new license. So as a consequence, all the matched fragments
+if stitched together, doesn't contain the whole text. This ``is_suggested_matched_text_complete``
+attribute has this information.
+
+.. note::
+
+    Now only issues with `is_license_text` as True has it's `is_suggested_matched_text_complete`
+    value as false.
+
+.. _issue_types_table:
+
+All Issue Types
+---------------
 
 .. list-table::
     :widths: 15 15
     :header-rows: 1
 
-    * - ``region_license_error_case``
-      - ``region_license_error_sub_case``
+    * - ``text/notice/tag/reference``
+      - ``issue_type::classification_id``
 
     * - ``text``
-      - ``legal-lic-files``
+      - ``text-legal-lic-files``
 
     * - ``text``
-      - ``non-legal-lic-files``
+      - ``text-non-legal-lic-files``
 
     * - ``text``
-      - ``lic-text-fragments``
+      - ``text-lic-text-fragments``
 
     * - ``notice``
-      - ``and-or-except-notice``
+      - ``notice-and-or-with-notice``
 
     * - ``notice``
-      - ``single-key-notice``
+      - ``notice-single-key-notice``
+
+    * - ``notice``
+      - ``notice-has-unknown-match``
+
+    * - ``notice``
+      - ``notice-false-positive``
 
     * - ``tag``
-      - ``tag-coverage``
+      - ``tag-tag-coverage``
 
     * - ``tag``
-      - ``other-tag-structures``
+      - ``tag-other-tag-structures``
 
     * - ``tag``
-      - ``false-positives``
+      - ``tag-false-positives``
 
     * - ``reference``
-      - ``lead-in-refs``
+      - ``reference-lead-in-or-unknown-refs``
 
     * - ``reference``
-      - ``low-coverage-refs``
+      - ``reference-low-coverage-refs``
 
     * - ``reference``
-      - ``unknown-refs``
+      - ``reference-to-local-file``
+
+    * - ``reference``
+      - ``reference-false-positive``
 
 .. _case_lic_text:
 
 License Texts
 -------------
 
-.. note::
-
-    Value of ``region_license_error_case`` :- ``text``
+All the `issue_types` with `is_license_text` as True.
 
 License Text Files
 ^^^^^^^^^^^^^^^^^^
 
 .. note::
 
-    Value of ``region_license_error_sub_case`` :- ``legal-lic-files``
+    Value of ``issue_type:classification_id`` :- ``text-legal-lic-files``
 
 - [More Than 90% License Words/Legal File]
 
@@ -115,7 +145,7 @@ License Texts in Files
 
 .. note::
 
-    Value of ``region_license_error_sub_case`` :- ``non-legal-lic-files``
+    Value of ``issue_type:classification_id`` :- ``text-non-legal-lic-files``
 
 - [with less than 90% License Words]
 
@@ -133,7 +163,7 @@ Full text doesn’t exist in matched_text
 
 .. note::
 
-    Value of ``region_license_error_sub_case`` :- ``lic-text-fragments``
+    Value of ``issue_type:classification_id`` :- ``text-lic-text-fragments``
 
 Where the Full text doesn’t exist in matched_text and we have to go to/fetch the source file which
 was scanned.
@@ -178,16 +208,14 @@ Clearly the actual license has a lot more text, which we can only get by going t
 License Notices
 ---------------
 
-.. note::
-
-    Value of ``region_license_error_case`` :- ``notice``
+All `issue_types` with their `is_license_notice` value as True.
 
 Exceptions, Rules with Keys having AND/OR
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. note::
 
-    Value of ``region_license_error_sub_case`` :- ``and-or-except-notice``
+    Value of ``issue_type:classification_id`` :- ``notice-and-or-with-notice``
 
 Where there are multiple "notice" license detections, not of the same license name, in a single
 file. These are often:
@@ -203,7 +231,7 @@ Single key notices
 
 .. note::
 
-    Value of ``region_license_error_sub_case`` :- ``single-key-notice``
+    Value of ``issue_type:classification_id`` :- ``notice-single-key-notice``
 
 This is the general case of License Notice cases, so if it's a license notice case and doesn't fall
 into the other license notice cases detailed below, then it belongs in this category.
@@ -216,16 +244,14 @@ crafted with fairly high confidence as almost always the entire text is present 
 License Tags
 ------------
 
-.. note::
-
-    Value of ``region_license_error_case`` :- ``tag``
+All `issue_types` with their `is_license_tag` value as True.
 
 Wrong License Tag Detections
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. note::
 
-    Value of ``region_license_error_sub_case`` :- ``tag-coverage``
+    Value of ``issue_type:classification_id`` :- ``tag-tag-coverage``
 
 Among all  “is_license_tag” = True cases, if match_coverage is less than 100, then it is a wrong
 license detection, and as tags are small and matched_text almost always contains the whole tag, a
@@ -239,7 +265,7 @@ Other common Structures of Tags
 
 .. note::
 
-    Value of ``region_license_error_sub_case`` :- ``other-tag-structures``
+    Value of ``issue_type:classification_id`` :- ``tag-other-tag-structures``
 
 There exists specific Tags, for group of projects, and these are mostly found in source code files,
 in the code itself.
@@ -263,13 +289,16 @@ Finding False Positives from License Tags Detections
 
 .. note::
 
-    Value of ``region_license_error_sub_case`` :- ``false-positives``
-    In this case, value of ``license_scan_analysis_result`` :- ``false-positives``
+    Value of ``issue_type:classification_id`` :- ``tag-false-positives``.
+    There also exists ``notice-false-positives`` and ``reference-false-positives``, similarly.
 
-Now, the “is_license_tag” is obviously always true for these, but the “match_coverage” is always 100
+    In these cases, value of ``issue_id`` :- ``false-positives``
+
+Now, the “is_license_tag” is mostly true for these, but the “match_coverage” is always 100
 in these cases. These are almost always wrongly detected by some handful of rules which has only the
-words gpl/lgpl or like that. So we further narrow our search down to only 1-word rules having
-is_license_tag = True.
+words gpl/lgpl or similar ones. So we further narrow our search down to only 1-3 word rules and
+and an additional criteria being if the license match occurs at line number more than a certain
+value, say 1000 or more.
 
 But this also includes a lot of correct detections, which are correctly detected.
 
@@ -285,27 +314,25 @@ The data needed to train that model, which we can get from two places:-
 
 We could make use of the classifier confidence scores to only look at ambigous cases only.
 
-Issue to be noted -
+.. note::
 
-In some cases some more lines above and below are needed to be added to these false_positive rules,
-as the ``matched_text`` can be too general for a false positive rule. This could require
-manual work.
+    In some cases some more lines above and below are needed to be added to these false_positive
+    rules, as the ``matched_text`` can be too general for a false positive rule. This could require
+    manual work.
 
 .. _case_lic_ref:
 
 License References
 ------------------
 
-.. note::
-
-    Value of ``region_license_error_case`` :- ``reference``
+All the `issue_types` with `is_license_reference` as True.
 
 Those with low match coverages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. note::
 
-    Value of ``region_license_error_sub_case`` :- ``low-coverage-refs``
+    Value of ``issue_type:classification_id`` :- ``reference-low-coverage-refs``
 
 This is the most common type of license detection errors, as there exist a lot of
 license references, and they can be added. These are also highly fixable problems, as almost always
@@ -321,7 +348,7 @@ unknown file license references
 
 .. note::
 
-    Value of ``region_license_error_sub_case`` :- ``unknown-refs``
+    Value of ``issue_type:classification_id`` :- ``reference-to-local-file``
 
 In many cases the license that is referred to is in another file, and only the filename is given,
 and not the license name. Example - "see license in file LICENSE.txt"
@@ -339,14 +366,14 @@ Introduction to a License Notice
 
 .. note::
 
-    Value of ``region_license_error_sub_case`` :- ``lead-in-refs``
+    Value of ``issue_type:classification_id`` :- ``reference-lead-in-or-unknown-refs``
 
 There are cases where the RULE name begins with ``lead-in_unknown_``, i.e. these are known lead-ins
 to licenses, so even if the exact license isn't detected, it can be reported that there is a
 license reference here.
 
-Here we could add to the Rulebase, the license reference, or as in the example case below, craft a
-new rule by joining the two existing ones
+Here we could add to the Scancode Rules, the license reference, or as in the example case below,
+craft a new rule by joining the two existing ones
 
 Example case:-
 

--- a/docs/source/how-analysis-is-performed/selecting-incorrect-unique.rst
+++ b/docs/source/how-analysis-is-performed/selecting-incorrect-unique.rst
@@ -10,17 +10,21 @@ are:
 4. Getting rid of same issues across package - :ref:`ignoring_same_cases_in_package`
 5. Resolving issues based on groups - :ref:`resolving_issues`
 
-.. _location_region_number:
+.. _location_regions_division:
 
 Dividing Matches into Region Groups
 -----------------------------------
 
-The attribute ``location_region_number`` in the analysis results has information on which
-file-region the match is in.
+All the matches detected in a file, are grouped into file-regions,
+(i.e. one file would have multiple, or at least one file-region) and then the analysis is
+performed separately on all these file-regions as these are to be handled independently
+from each other.
 
-.. note::
+These 3 attributes in the analysis results has information on which file-region the matches are in.
 
-    The values of ``location_region_number`` are positive integers starting from 1.
+1. ``start_line_region`` - The line number where this current file region starts from, in the file.
+2. ``end_line_region`` - The line number where this current file region ends at, in the file.
+3. ``license_matches`` - All the matches detected by scancode that are in this file-region.
 
 .. _file_region:
 
@@ -75,13 +79,14 @@ File-Region Grouping Algorithm
 
 Algorithm as for Grouping based on Location -
 
-- Step 1: Start from the first match, and set it's start/end line as the group boundary.
-- Step 2: Go by every match executing these instructions :-
-    - If entirely inside the boundary, drop.
-    - If partly inside the boundary, extend boundaries to include this and then drop.
-    - If very close to boundary, i.e. less than a threshold, extend boundaries to include.
+- Step 1: Start from the first match, and assign it into the first group.
+- Step 2: Initialize boundaries to the start/end line of this match.
+- Step 3: Go by every match executing these instructions :-
+    - If entirely inside the boundary, include in the current group.
+    - If partly inside the boundary, extend boundaries and include in the current group.
+    - If very close to boundary, i.e. less than a threshold, extend boundaries and include in the current group.
     - Else, if outside boundary, go to step 1 making this match as a new group.
-- Repeat until there’s no groups left.
+- Repeat until there’s no matches left.
 
 As there’s never too many detections in a file, and there’s almost always detections which have
 almost all of the matched texts, and as the matches are sorted according to their start/end lines,
@@ -89,8 +94,8 @@ this is efficient enough, and passes through the list of matches once.
 
 .. _license_scan_analysis_result:
 
-Only Selecting Files with Incorrect Scans
------------------------------------------
+File-regions with Incorrect Scans
+---------------------------------
 
 The attribute ``license_scan_analysis_result`` in the analysis results has information on if the
 file-region has any license detection issue in it, bases on coverage values, presence of extra words

--- a/docs/source/how-analysis-is-performed/selecting-incorrect-unique.rst
+++ b/docs/source/how-analysis-is-performed/selecting-incorrect-unique.rst
@@ -4,8 +4,8 @@ Selecting Incorrect Scan Cases
 The steps of analysing license matches in a file and flagging potential license detection issues
 are:
 
-1. Dividing Matches in file-regions - :ref:`location_region_number`
-2. Detecting License Detection Issues in file-regions - :ref:`license_scan_analysis_result`
+1. Dividing Matches in file-regions - :ref:`location_regions_division`
+2. Detecting License Detection Issues in file-regions - :ref:`analysis`
 3. Grouping the issues into classes and subclasses of issues - :ref:`dividing_into_more_cases`
 4. Getting rid of same issues across package - :ref:`ignoring_same_cases_in_package`
 5. Resolving issues based on groups - :ref:`resolving_issues`
@@ -15,16 +15,16 @@ are:
 Dividing Matches into Region Groups
 -----------------------------------
 
-All the matches detected in a file, are grouped into file-regions,
+All the matches detected in a file, are grouped into `file-regions <file_region>`_,
 (i.e. one file would have multiple, or at least one file-region) and then the analysis is
 performed separately on all these file-regions as these are to be handled independently
 from each other.
 
 These 3 attributes in the analysis results has information on which file-region the matches are in.
 
-1. ``start_line_region`` - The line number where this current file region starts from, in the file.
-2. ``end_line_region`` - The line number where this current file region ends at, in the file.
-3. ``license_matches`` - All the matches detected by scancode that are in this file-region.
+1. ``start_line`` - The line number where this current file region starts from, in the file.
+2. ``end_line`` - The line number where this current file region ends at, in the file.
+3. ``original_license`` - All the matches detected by scancode that are in this file-region.
 
 .. _file_region:
 
@@ -84,7 +84,8 @@ Algorithm as for Grouping based on Location -
 - Step 3: Go by every match executing these instructions :-
     - If entirely inside the boundary, include in the current group.
     - If partly inside the boundary, extend boundaries and include in the current group.
-    - If very close to boundary, i.e. less than a threshold, extend boundaries and include in the current group.
+    - If very close to boundary, i.e. less than a threshold, extend boundaries and include in the
+      current group.
     - Else, if outside boundary, go to step 1 making this match as a new group.
 - Repeat until there’s no matches left.
 
@@ -92,7 +93,7 @@ As there’s never too many detections in a file, and there’s almost always de
 almost all of the matched texts, and as the matches are sorted according to their start/end lines,
 this is efficient enough, and passes through the list of matches once.
 
-.. _license_scan_analysis_result:
+.. _analysis:
 
 File-regions with Incorrect Scans
 ---------------------------------
@@ -103,16 +104,17 @@ or false positive tags.
 
 .. note::
 
-    The 5 possible values of ``license_scan_analysis_result`` are:
+    The 6 possible values of ``license_scan_analysis_result`` are:
 
     1. ``correct-license-detection``
-    2. ``imperfect_match_coverage``
-    3. ``near_perfect_match_coverage``
-    4. ``extra_words``
-    5. ``false_positives``
+    2. ``imperfect-match-coverage``
+    3. ``near-perfect-match-coverage``
+    4. ``extra-words``
+    5. ``false-positive``
+    6. ``unknown-match``
 
-Scancode detects most licenses accurately, so our focus is only on the parts where the detection is
-poor, and so primarily in the first step we separate this from the Correct Scans.
+Scancode detects most licenses accurately, so our focus is only on the parts where the detection has
+issues, and so primarily in the first step we separate this from the Correct Scans.
 
 Initially from the `matcher` information we can say that
 IF the license matcher is “1-hash” or “4-spdx-id” they are correct matches, all incorrect matches
@@ -149,20 +151,28 @@ There is also another case where ``score != matched_coverage * rule_relevance``,
 some extra words, i.e. the entire rule was matched, but there were some extra words which caused the
 decrease in score.
 
-So the 3 category of errors as classified in this step are::
+So the 3 category of issues as classified in this step are::
 
-    2. ``imperfect_match_coverage``
-    3. ``near_perfect_match_coverage``
-    4. ``extra_words``
+    2. ``imperfect-match-coverage``
+    3. ``near-perfect-match-coverage``
+    4. ``extra-words``
 
 Also note that this order is important, as if any one of the matches has this case, the entire file
 will be flagged as such.
 
-And another case taking into account the false-positives, which would be single-match, i.e.
-entire file will not be flagged in the same error. This is the ``Step 3`` and here a
-NLP sentence Classifier could be used to improve accuracy. The error class is called::
+And another case taking into account the false-positives, where the rule length would be
+less than a threshold (i.e. say less than 4 words) and the start-line of the match should
+be more than a threshold (i.e. say more than 1000) for it to be considered a false positive.
 
-    5. ``false_positives``
+This is the ``Step 3`` and here a NLP sentence Classifier could be used to improve accuracy.
+The issue class is called::
+
+    5. ``false-positives``
+
+Even if all the matches has perfect `match_coverage`, if there are `unknown` license
+matches there, there's likely a license detection issue. This issue is a::
+
+    6. ``unknown-match``
 
 .. _dividing_into_more_cases:
 
@@ -186,14 +196,14 @@ Ignoring Same Incorrect Scans, Package Wise
 So in Scancode, most of the code files have the same header license notice, and some of them, which
 are derived from other packages, have other different license notices.
 
-Now this practice is common across a lot of packages, as license notices/referances/tags, or in
+Now this practice is common across a lot of packages, as license notices/references/tags, or in
 some cases even entire texts(I’ve not encountered examples of these?) being present in a lot of
 files. Now naturally if one of these is not detected correctly by scancode license detection,
 other exactly similar ones will also be not detected correctly.
 
 We need not have all of these incorrect matches, we only need one of every unique case.
 
-So in order to select only unique ones, we use a combination of “matched_rule_identifier”
+So in order to report only unique ones, we use a combination of “matched_rule_identifier”
 and “match_coverage” to determine uniqueness of the matches. But we use this file-wise.
 
 I.e. the policy is::
@@ -201,6 +211,9 @@ I.e. the policy is::
     If multiple files have the same N number of matches, all these matches having same
     “matched_rule_identifier” and “match_coverage” across these multiple files, we keep only
     one file among them and discard the others.
+
+This is performed in the summary plugin, where all the unique license detection issues are
+reported in the summary together, each with a list of their occurrences.
 
 For example, in `scancode-toolkit#1920 <https://github.com/nexB/scancode-toolkit/issues/1920>`_, socat-2.0.0 has
 multiple (6) files with each file having the same 3 matched rules and match_coverage sets, i.e. -

--- a/docs/source/improving-scancode/crafting-rules.rst
+++ b/docs/source/improving-scancode/crafting-rules.rst
@@ -5,7 +5,8 @@ Crafting Rules From Fragments of Matched Text
 
 .. note::
 
-    This plugin is Work In Progress.
+    The rule/.yml file generation/other actions is Work In Progress.
+    Only reports with suggested rules with the rule text, license key, rule type is generated.
 
 The functions from stitching are implemented using the same algorithm mentioned above in Deleting
 Correct scans Location wise in File, because this is also done location wise, and wrt start and

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,17 +35,15 @@ API and Output Formats
 
    api-and-outputs/index
 
-Improving Scancode
-------------------
+Using this Analysis
+-------------------
 
 .. toctree::
    :maxdepth: 3
 
-   improving-scancode/index
+   analysis-use-case/index
 
 Indices and tables
 ==================
 
-* :ref:`genindex`
-* :ref:`modindex`
 * :ref:`search`


### PR DESCRIPTION
Analysis report now has 
1. the matches in the file-region 
2.  post-analysis match creation system
3. description fields for explaining the analysis result.

Analysis reports are now per file-region, rather than being per-match.

RTD errors also fixed. [Docs Page of Forked Repo](https://scancode-results-analyzer-fork-ayan.readthedocs.io/en/docs-update-format/)